### PR TITLE
docs: typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pnpm dev
 pnpm build
 ```
 ## Notes
-- This app checks updates via GitHub API, which will be automatically expired once it is uploaded publically in GitHub. Therefore, during development, please create a token yourself and place it in `Octokit.auth` inside `electron/main/index.ts`.
+- This app checks for updates via the GitHub API, which will automatically expire once it is uploaded publicly on GitHub. Therefore, during development, please create a token yourself and place it in `Octokit.auth` inside `electron/main/index.ts`.
 ```ts
   const { Octokit } = require("@octokit/core")
   const octokit = new Octokit({


### PR DESCRIPTION
## PR Type
Documentation Update

## Issues Facing
Mistyped description in Project ReadMe documentation.

## Changes Made
1. Added "for" after "checks" to make it grammatically correct,
2. Changed "publically" to "publicly", as "publicly" is the correct spelling,
3. Added "on" before "GitHub" for better sentence structure.
